### PR TITLE
Fix smbclient_state_init argument order

### DIFF
--- a/src/NativeServer.php
+++ b/src/NativeServer.php
@@ -25,7 +25,7 @@ class NativeServer extends Server {
 			list($workgroup, $user) = explode($user, '/');
 		}
 		$this->state = smbclient_state_new();
-		$result = smbclient_state_init($this->state, $workgroup, $this->getPassword(), $user);
+		$result = smbclient_state_init($this->state, $workgroup, $user, $this->getPassword());
 		if (!$result) {
 			throw new ConnectionError();
 		}

--- a/src/NativeShare.php
+++ b/src/NativeShare.php
@@ -65,7 +65,7 @@ class NativeShare implements IShare {
 			list($workgroup, $user) = explode($user, '/');
 		}
 		$this->state = smbclient_state_new();
-		$result = smbclient_state_init($this->state, $workgroup, $this->server->getPassword(), $user);
+		$result = smbclient_state_init($this->state, $workgroup, $user, $this->server->getPassword());
 		if (!$result) {
 			throw new ConnectionError();
 		}


### PR DESCRIPTION
`smbclient_state_init` takes arguments in the order 'workgroup', 'user', 'password'.
