### PR TITLE
fix close connection

### DIFF
--- a/src/RawConnection.php
+++ b/src/RawConnection.php
@@ -149,6 +149,14 @@ class RawConnection {
 			return;
 		}
 		if ($terminate) {
+			$status = proc_get_status($this->process);
+			$ppid = $status['pid'];
+			$pids = preg_split('/\s+/', `ps -o pid --no-heading --ppid $ppid`);
+			foreach($pids as $pid) {
+				if(is_numeric($pid)) {
+					posix_kill($pid, 9); //9 is the SIGKILL signal
+				}
+			}
 			proc_terminate($this->process);
 		}
 		proc_close($this->process);


### PR DESCRIPTION
close method of RawConnection.php file leaves child processes of
smbclient running which slows down the system.  See [1]

1- http://php.net/manual/en/function.proc-terminate.php