### PR TITLE
Fix for allfinfo and parsStat for non Windows Fileservers

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -92,6 +92,11 @@ class Parser {
 		$size = 0;
 		foreach ($output as $line) {
 			list($name, $value) = explode(':', $line, 2);
+			// A line = explode statement may not fill all array elements
+			// properly. May happen when accessing non Windows Fileservers
+			$words = explode(':', $line, 2);
+			$name = isset($words[0]) ? $words[0] : '';
+			$value = isset($words[1]) ? $words[1] : '';
 			$value = trim($value);
 			if ($name === 'write_time') {
 				$mtime = strtotime($value);

--- a/src/Share.php
+++ b/src/Share.php
@@ -120,6 +120,12 @@ class Share implements IShare {
 	public function stat($path) {
 		$escapedPath = $this->escapePath($path);
 		$output = $this->execute('allinfo ' . $escapedPath);
+		// Windows and non Windows Fileserver may respond different
+		// to the allinfo command for directories. If the result is a single
+		// line = error line, redo it with a different allinfo parameter
+		if ($escapedPath == '""' && count($output) < 2) {
+			$output = $this->execute('allinfo ' . '"."');
+		}
 		if (count($output) < 3) {
 			$this->parseOutput($output, $path);
 		}


### PR DESCRIPTION
This is the fix for:
https://github.com/icewind1991/SMB/issues/23
https://github.com/owncloud/core/issues/14347

It addresses following two issues:

1. Share.php: non Windows Fileservers may respond to a allinfo directory query ``allinfo ""``with an error instead the result. The query must be redone wih ``allinfo "."``
2. Parse.php: non Windows Fileserver may add additional lines which can not be easily split because of to less possible array elements

