### PR TITLE
close smbclient connections properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 vendor
+composer.lock

--- a/example.php
+++ b/example.php
@@ -1,0 +1,20 @@
+<?php
+use Icewind\SMB\NativeServer;
+use Icewind\SMB\Server;
+
+require('vendor/autoload.php');
+
+if (Server::NativeAvailable()) {
+	$server = new NativeServer('localhost', 'test', 'test');
+} else {
+	$server = new Server('localhost', 'test', 'test');
+}
+
+$share = $server->getShare('test');
+
+$share->put(__FILE__, 'example.php');
+
+$files = $share->dir('/');
+foreach ($files as $file) {
+	echo $file->getName() . "\n";
+}

--- a/src/RawConnection.php
+++ b/src/RawConnection.php
@@ -149,17 +149,15 @@ class RawConnection {
 			return;
 		}
 		if ($terminate) {
-			$status = proc_get_status($this->process);
-			$ppid = $status['pid'];
-			$pids = preg_split('/\s+/', `ps -o pid --no-heading --ppid $ppid`);
-			foreach($pids as $pid) {
-				if(is_numeric($pid)) {
-					// try for case that posix_ functions are not available
-					try {
+			// if for case that posix_ functions are not available
+			if (function_exists('posix_kill')) {
+				$status = proc_get_status($this->process);
+				$ppid = $status['pid'];
+				$pids = preg_split('/\s+/', `ps -o pid --no-heading --ppid $ppid`);
+				foreach($pids as $pid) {
+					if(is_numeric($pid)) {
 						//9 is the SIGKILL signal
 						posix_kill($pid, 9);
-					} catch (\Exception $e) {
-						throw $e;
 					}
 				}
 			}

--- a/src/RawConnection.php
+++ b/src/RawConnection.php
@@ -149,15 +149,17 @@ class RawConnection {
 			return;
 		}
 		if ($terminate) {
-			// if for case that posix_ functions are not available
-			if (function_exists('posix_kill')) {
-				$status = proc_get_status($this->process);
-				$ppid = $status['pid'];
-				$pids = preg_split('/\s+/', `ps -o pid --no-heading --ppid $ppid`);
-				foreach($pids as $pid) {
-					if(is_numeric($pid)) {
+			$status = proc_get_status($this->process);
+			$ppid = $status['pid'];
+			$pids = preg_split('/\s+/', `ps -o pid --no-heading --ppid $ppid`);
+			foreach($pids as $pid) {
+				if(is_numeric($pid)) {
+					// try for case that posix_ functions are not available
+					try {
 						//9 is the SIGKILL signal
 						posix_kill($pid, 9);
+					} catch (\Exception $e) {
+						throw $e;
 					}
 				}
 			}

--- a/src/RawConnection.php
+++ b/src/RawConnection.php
@@ -149,6 +149,20 @@ class RawConnection {
 			return;
 		}
 		if ($terminate) {
+			$status = proc_get_status($this->process);
+			$ppid = $status['pid'];
+			$pids = preg_split('/\s+/', `ps -o pid --no-heading --ppid $ppid`);
+			foreach($pids as $pid) {
+				if(is_numeric($pid)) {
+					// try for case that posix_ functions are not available
+					try {
+						//9 is the SIGKILL signal
+						posix_kill($pid, 9);
+					} catch (\Exception $e) {
+						throw $e;
+					}
+				}
+			}
 			proc_terminate($this->process);
 		}
 		proc_close($this->process);


### PR DESCRIPTION
This PR supersedes #22

It does the same but adds a try/catch around the posix_ function to do proper handling if it is not available. owncloud, where this SMB implementation is used as 3rdparty module has the requirement, that php posix functions have to be available anyway. This is also documented in their admin manual https://github.com/owncloud/documentation/blob/master/admin_manual/installation/source_installation.rst#prerequisites

A merge of this PR and #25 and the update in owncloud would greatly improve SMB

@icewind1991 @Xenopathic 