### PR TITLE
Close smbclient connections properly (#2)

### DIFF
--- a/src/RawConnection.php
+++ b/src/RawConnection.php
@@ -149,6 +149,18 @@ class RawConnection {
 			return;
 		}
 		if ($terminate) {
+			// if for case that posix_ functions are not available
+			if (function_exists('posix_kill')) {
+				$status = proc_get_status($this->process);
+				$ppid = $status['pid'];
+				$pids = preg_split('/\s+/', `ps -o pid --no-heading --ppid $ppid`);
+				foreach($pids as $pid) {
+					if(is_numeric($pid)) {
+						//9 is the SIGKILL signal
+						posix_kill($pid, 9);
+					}
+				}
+			}
 			proc_terminate($this->process);
 		}
 		proc_close($this->process);


### PR DESCRIPTION
This PR supersedes #22

It does the same but adds a if(function_exists('posix_kill ')) to skip the function if it is not available. 

owncloud, where this SMB implementation is used as 3rdparty module has the requirement, that php posix functions have to be available anyway. This is also documented in their admin manual https://github.com/owncloud/documentation/blob/master/admin_manual/installation/source_installation.rst#prerequisites

A merge of this PR and #25 and an update to owncloud would greatly improve the SMB functionality there !

@icewind1991 @Xenopathic

Note: this PR has been already made once but I needed to close it because of a problem in my dev environment