### PR TITLE
RawConnection.php: add workgroup to auth file

### DIFF
--- a/src/RawConnection.php
+++ b/src/RawConnection.php
@@ -131,12 +131,18 @@ class RawConnection {
 		return $this->pipes[5];
 	}
 
-	public function writeAuthentication($user, $password) {
-		$auth = ($password === false)
-			? "username=$user"
-			: "username=$user\npassword=$password";
-
-		if (fwrite($this->getAuthStream(), $auth) === false) {
+	public function writeAuthentication($workgroup, $user, $password) {
+		$auth = array();
+		if (is_string($workgroup)) {
+			$auth[] = "domain=$workgroup";
+		}
+		if (is_string($user)) {
+			$auth[] = "username=$user";
+		}
+		if (is_string($password)) {
+			$auth[] = "password=$password";
+		}
+		if (fwrite($this->getAuthStream(), implode("\n", $auth)) === false) {
 			fclose($this->getAuthStream());
 			return false;
 		}

--- a/src/Server.php
+++ b/src/Server.php
@@ -118,7 +118,7 @@ class Server {
 		$command = Server::CLIENT . $workgroupArgument . ' --authentication-file=/proc/self/fd/3' .
 			' -gL ' . escapeshellarg($this->getHost());
 		$connection = new RawConnection($command);
-		$connection->writeAuthentication($this->getUser(), $this->getPassword());
+		$connection->writeAuthentication($this->getWorkgroup(), $this->getUser(), $this->getPassword());
 		$output = $connection->readAll();
 
 		$line = $output[0];

--- a/src/Share.php
+++ b/src/Share.php
@@ -61,7 +61,7 @@ class Share extends AbstractShare {
 			escapeshellarg('//' . $this->server->getHost() . '/' . $this->name)
 		);
 		$this->connection = new Connection($command);
-		$this->connection->writeAuthentication($this->server->getUser(), $this->server->getPassword());
+		$this->connection->writeAuthentication($this->server->getWorkgroup(), $this->server->getUser(), $this->server->getPassword());
 		if (!$this->connection->isValid()) {
 			throw new ConnectionException();
 		}
@@ -69,7 +69,7 @@ class Share extends AbstractShare {
 
 	protected function reconnect() {
 		$this->connection->reconnect();
-		$this->connection->writeAuthentication($this->server->getUser(), $this->server->getPassword());
+		$this->connection->writeAuthentication($this->server->getWorkgroup(), $this->server->getUser(), $this->server->getPassword());
 		if (!$this->connection->isValid()) {
 			throw new ConnectionException();
 		}
@@ -263,7 +263,7 @@ class Share extends AbstractShare {
 			escapeshellarg('//' . $this->server->getHost() . '/' . $this->name)
 		);
 		$connection = new Connection($command);
-		$connection->writeAuthentication($this->server->getUser(), $this->server->getPassword());
+		$connection->writeAuthentication($this->server->getWorkgroup(), $this->server->getUser(), $this->server->getPassword());
 		$connection->write('get ' . $source . ' /proc/self/fd/5');
 		$connection->write('exit');
 		$fh = $connection->getFileOutputStream();
@@ -291,7 +291,7 @@ class Share extends AbstractShare {
 			escapeshellarg('//' . $this->server->getHost() . '/' . $this->name)
 		);
 		$connection = new Connection($command);
-		$connection->writeAuthentication($this->server->getUser(), $this->server->getPassword());
+		$connection->writeAuthentication($this->server->getWorkgroup(), $this->server->getUser(), $this->server->getPassword());
 		$fh = $connection->getFileInputStream();
 
 		$connection->write('put /proc/self/fd/4 ' . $target);


### PR DESCRIPTION
I read somewhere in a discussion about libsmbclient-php that people were having trouble with SMB and workgroups when using the `smbclient` binary. Maybe it's because the workgroup parameter is not being passed to `smbclient` in the auth file? This pull request, which is based on similar code in SambaDAV, adds support for that parameter. Beware that I haven't actually tested or ran this code.