### PR TITLE
fix parsing smbclient aillinfo attribute value

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -108,7 +108,7 @@ class Parser {
 			if ($name === 'write_time') {
 				$mtime = strtotime($value);
 			} else if ($name === 'attributes') {
-				$mode = hexdec(substr($value, 1, -1));
+				$mode =  $this->parseMode($value);
 			} else if ($name === 'stream') {
 				list(, $size,) = explode(' ', $value);
 				$size = intval($size);


### PR DESCRIPTION
smbclient `Version 4.3.9-Ubuntu` outputs `attributes: HSD (16)`.
