### PR TITLE
Reuse of Apache Kerberos Ticket

### DIFF
--- a/example-apache-kerberos.php
+++ b/example-apache-kerberos.php
@@ -1,0 +1,19 @@
+<?php
+
+require('vendor/autoload.php');
+
+// dfs paths not working
+$host = 'dc.domain.local';
+$share = 'netlogon';
+
+$auth = new \Icewind\SMB\KerberosApacheAuth();
+$serverFactory = new \Icewind\SMB\ServerFactory();
+
+$server = $serverFactory->createServer($host, $auth);
+
+$share = $server->getShare($share);
+
+$files = $share->dir('/');
+foreach ($files as $file) {
+	echo $file->getName() . "\n";
+}

--- a/src/KerberosApacheAuth.php
+++ b/src/KerberosApacheAuth.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Icewind\SMB;
+
+use Icewind\SMB\Exception\DependencyException;
+use Icewind\SMB\Exception\Exception;
+
+
+/**
+ * Use existing kerberos ticket to authenticate and reuse the apache ticket cache (mod_auth_kerb) 
+ */
+class KerberosApacheAuth extends KerberosAuth implements IAuth {
+
+        private $ticketPath = "";
+
+        //only working with specific library (mod_auth_kerb, krb5, smbclient) versions
+        private $saveTicketInMemory = false;
+
+	public function __construct($saveTicketInMemory = false) {
+
+		$this->saveTicketInMemory = $saveTicketInMemory;
+		$this->registerApacheKerberosTicket();
+
+	}
+
+	private function registerApacheKerberosTicket() {
+
+		// inspired by https://git.typo3.org/TYPO3CMS/Extensions/fal_cifs.git
+
+		if (!extension_loaded("krb5")) {
+
+			// https://pecl.php.net/package/krb5
+			throw new DependencyException('Ensure php-krb5 is installed.');
+		}
+
+		//read apache kerberos ticket cache
+		$cacheFile = getenv("KRB5CCNAME");
+		if(!$cacheFile) {
+
+			throw new Exception('No kerberos ticket cache environment variable (KRB5CCNAME) found.');
+
+		}
+
+		$krb5 = new \KRB5CCache();
+		$krb5->open($cacheFile);
+		if(!$krb5->isValid()) {
+			throw new Exception('Kerberos ticket cache is not valid.');
+		}
+
+
+		if($this->saveTicketInMemory) {
+			putenv("KRB5CCNAME=" . $krb5->getName());
+		}
+		else {
+			//workaround: smbclient is not working with the original apache ticket cache.
+			$tmpFilename = tempnam("/tmp", "krb5cc_php_");
+			$tmpCacheFile = "FILE:" . $tmpFilename;
+			$krb5->save($tmpCacheFile);
+			$this->ticketPath = $tmpFilename;
+			putenv("KRB5CCNAME=" . $tmpCacheFile);
+		}
+
+	}
+
+
+	public function __destruct() {
+
+		if(!empty($this->ticketPath) && file_exists($this->ticketPath)  && is_file($this->ticketPath)) {
+
+			   unlink($this->ticketPath);
+
+		}
+	}
+
+}

--- a/src/KerberosAuth.php
+++ b/src/KerberosAuth.php
@@ -25,16 +25,6 @@ namespace Icewind\SMB;
  * Use existing kerberos ticket to authenticate
  */
 class KerberosAuth implements IAuth {
-        
-	private $ticketPath = "";
-
-	//not working with nextcloud
-        private $saveTicketInMemory = false;
-
-	public function __construct() {
-		$this->registerApacheKerberosTicket();
-	}
-
 	public function getUsername() {
 		return 'dummy';
 	}
@@ -54,41 +44,6 @@ class KerberosAuth implements IAuth {
 	public function setExtraSmbClientOptions($smbClientState) {
 		smbclient_option_set($smbClientState, SMBCLIENT_OPT_USE_KERBEROS, true);
 		smbclient_option_set($smbClientState, SMBCLIENT_OPT_FALLBACK_AFTER_KERBEROS, false);
-	}
-
-	private function registerApacheKerberosTicket() {
-		// inspired by https://git.typo3.org/TYPO3CMS/Extensions/fal_cifs.git
-	 
-		if (!extension_loaded("krb5")) {
-			return;
-		}
-		//read apache kerberos ticket cache
-		$cacheFile = getenv("KRB5CCNAME");
-		if(!$cacheFile) {
-			return;
-		}
-		$krb5 = new \KRB5CCache();
-		$krb5->open($cacheFile);
-		if(!$krb5->isValid()) {
-			return;
-		}
-		if($this->saveTicketInMemory) {
-			putenv("KRB5CCNAME=" . $krb5->getName());
-		}
-		else {
-			//workaround: smbclient is not working with the original apache ticket cache.
-			$tmpFilename = tempnam("/tmp", "krb5cc_php_");
-			$tmpCacheFile = "FILE:" . $tmpFilename;
-			$krb5->save($tmpCacheFile);
-			$this->ticketPath = $tmpFilename;
-			putenv("KRB5CCNAME=" . $tmpCacheFile);
-		}
-	}
-	
-	public function __destruct() {
-		if(!empty($this->ticketPath) && file_exists($this->ticketPath)  && is_file($this->ticketPath)) {
-			   unlink($this->ticketPath);
-		}
 	}
 
 }

--- a/src/Native/NativeState.php
+++ b/src/Native/NativeState.php
@@ -34,6 +34,10 @@ class NativeState {
 	protected $handlerSet = false;
 
 	protected $connected = false;
+	
+	// sync the garbage collection cycle 
+        // __deconstruct() of KerberosAuth should not called too soon
+        protected $auth;
 
 	// see error.h
 	const EXCEPTION_MAP = [
@@ -85,6 +89,11 @@ class NativeState {
 		$this->state = smbclient_state_new();
 		smbclient_option_set($this->state, SMBCLIENT_OPT_AUTO_ANONYMOUS_LOGIN, false);
 		$auth->setExtraSmbClientOptions($this->state);
+		
+                // sync the garbage collection cycle
+                // __deconstruct() of KerberosAuth should not called too soon
+                $this->auth = $auth;
+
 		$result = @smbclient_state_init($this->state, $auth->getWorkgroup(), $auth->getUsername(), $auth->getPassword());
 
 		$this->testResult($result, '');


### PR DESCRIPTION
I've found that a cached Apache ticket can not be used immediately by the php-smbclient library. In my workaround, I use the krb5 php-lib to convert the ticket in the correct format. With this modification it is possible to authenticate cifs-shares with a kerberos sso-ticket. Apache only creates a ticket cache when you enable Kerberos delegation.