### PR TITLE
Move the php-cs-fixer to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
 	],
 	"require"          : {
 		"php": ">=5.6",
-		"icewind/streams": ">=0.2.0",
-		"friendsofphp/php-cs-fixer": "^2.13"
+		"icewind/streams": ">=0.2.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7"
+		"phpunit/phpunit": "^5.7",
+		"friendsofphp/php-cs-fixer": "^2.13"
 	},
 	"autoload"         : {
 		"psr-4": {


### PR DESCRIPTION
As far as I understand it the dependency "friendsofphp/php-cs-fixer" is only used for development, correct? So it could be safely moved to "require-dev" from "require" in the composer.json?