### PR TITLE
Fix connection->read() when first line is not prompt.

### DIFF
--- a/src/Wrapped/Connection.php
+++ b/src/Wrapped/Connection.php
@@ -66,7 +66,11 @@ class Connection extends RawConnection {
 		$this->parser->checkConnectionError($promptLine);
 
 		$output = [];
-		$line = $this->readLine();
+		if (!$this->isPrompt($promptLine)) {
+			$line = $promptLine;
+		} else {
+			$line = $this->readLine();
+		}
 		if ($line === false) {
 			$this->unknownError($promptLine);
 		}


### PR DESCRIPTION
Causes this: https://github.com/nextcloud/server/issues/14441

In https://github.com/nextcloud/server/blob/master/apps/files_external/lib/Command/Notify.php
NotifyHandler getChanges() is used before connection->read() which means read() do not have prompt as first line.

In occ files_external:notify, the very first registert even never gets registered.

Probably could make this cleaner though. What do you think? @icewind1991 