### PR TITLE
fixes #62

### DIFF
--- a/src/Wrapped/Connection.php
+++ b/src/Wrapped/Connection.php
@@ -45,9 +45,8 @@ class Connection extends RawConnection {
 	 * @throws ConnectException
 	 */
 	public function clearTillPrompt(): void {
-		$this->write('');
 		do {
-			$promptLine = $this->readLine();
+			$promptLine = $this->readLine(6);
 			if ($promptLine === false) {
 				break;
 			}
@@ -75,7 +74,7 @@ class Connection extends RawConnection {
 		if (!$this->isValid()) {
 			throw new ConnectionException('Connection not valid');
 		}
-		$promptLine = $this->readLine(); //first line is prompt
+		$promptLine = $this->readLine(6); //first line is prompt
 		if ($promptLine === false) {
 			$this->unknownError($promptLine);
 		}

--- a/src/Wrapped/RawConnection.php
+++ b/src/Wrapped/RawConnection.php
@@ -112,10 +112,11 @@ class RawConnection {
 	/**
 	 * read a line of output
 	 *
+	 * @param  int $length
 	 * @return string|false
 	 */
-	public function readLine() {
-		return stream_get_line($this->getOutputStream(), 4086, "\n");
+	public function readLine($length=4086) {
+		return stream_get_line($this->getOutputStream(), $length, "\n");
 	}
 
 	/**


### PR DESCRIPTION
issue #62 is definitely a problem. smbclient v4.8.x is affected as well.

The problem is likely to be that >= smbclient 4.7 the `smb: \>` prompt is not followed by a `\n`.
This will lead to a block by `stream_get_line()` since stream_get_line wants to read 4086 bytes or until a new line is found. Since there is no `\n` anymore stream_get_line() will block until there are 4086bytes to read.

I've encountered this after migrating to alpine which ships smbclient 4.8.8.
This pr will introduce a workaround to only read 6 bytes and check if it contains the smb prompt.