### PR TITLE
smbclient wrapper not compatible with busybox

### DIFF
--- a/src/Native/NativeShare.php
+++ b/src/Native/NativeShare.php
@@ -289,7 +289,7 @@ class NativeShare extends AbstractShare {
 	 */
 	public function append($source) {
 		$url = $this->buildUrl($source);
-		$handle = $this->getState()->open($url, "a");
+		$handle = $this->getState()->open($url, "a+");
 		return NativeWriteStream::wrap($this->getState(), $handle, "a", $url);
 	}
 

--- a/src/Wrapped/RawConnection.php
+++ b/src/Wrapped/RawConnection.php
@@ -173,18 +173,6 @@ class RawConnection {
 			return;
 		}
 		if ($terminate) {
-			// if for case that posix_ functions are not available
-			if (function_exists('posix_kill')) {
-				$status = proc_get_status($this->process);
-				$ppid = $status['pid'];
-				$pids = preg_split('/\s+/', `ps -o pid --no-heading --ppid $ppid`);
-				foreach ($pids as $pid) {
-					if (is_numeric($pid)) {
-						//9 is the SIGKILL signal
-						posix_kill($pid, 9);
-					}
-				}
-			}
 			proc_terminate($this->process);
 		}
 		proc_close($this->process);

--- a/src/Wrapped/Share.php
+++ b/src/Wrapped/Share.php
@@ -55,6 +55,8 @@ class Share extends AbstractShare {
 		FileInfo::MODE_SYSTEM   => 's'
 	];
 
+	const EXEC_CMD = 'exec';
+
 	/**
 	 * @param IServer $server
 	 * @param string $name
@@ -78,7 +80,8 @@ class Share extends AbstractShare {
 
 	protected function getConnection() {
 		$command = sprintf(
-			'%s%s -t %s %s %s %s',
+			'%s %s%s -t %s %s %s %s',
+			self::EXEC_CMD,
 			$this->system->getStdBufPath() ? $this->system->getStdBufPath() . ' -o0 ' : '',
 			$this->system->getSmbclientPath(),
 			$this->server->getOptions()->getTimeout(),


### PR DESCRIPTION
I have migrated to alpine, php7.3 and smbclient 4.8 from debian, php7.2 and smbclient 4.5. 
PR #78 already fixes one issue.

I've encountered two other bugs:

* `ps -o pid --no-heading --ppid $ppid` those params are not available on every posix system. For example alpine ships with busybox which does not know those parameters. 
Using exec to start smbclient will replace the shell itself and smbclient does not get forked off. This should resolve the need to search for child procs and killing them manually.

* Another issue is that using `append()` will result in smb error code `6` somehow. Strangely changing the smb mode to `a+` from `a` will resolve this issue as well. I'm not exactly sure why this is required now since i've not entirely reverse engineered this problem.