### PR TITLE
Only open target if source can be opened

### DIFF
--- a/src/Native/NativeShare.php
+++ b/src/Native/NativeShare.php
@@ -223,6 +223,12 @@ class NativeShare extends AbstractShare {
 		if (!$target) {
 			throw new InvalidPathException('Invalid target path: Filename cannot be empty');
 		}
+
+		$sourceHandle = $this->getState()->open($this->buildUrl($source), 'r');
+		if (!$sourceHandle) {
+			throw new InvalidResourceException('Failed opening remote file "' . $source . '" for reading');
+		}
+
 		$targetHandle = @fopen($target, 'wb');
 		if (!$targetHandle) {
 			$error = error_get_last();
@@ -231,13 +237,8 @@ class NativeShare extends AbstractShare {
 			} else {
 				$reason = 'Unknown error';
 			}
+			$this->getState()->close($sourceHandle);
 			throw new InvalidResourceException('Failed opening local file "' . $target . '" for writing: ' . $reason);
-		}
-
-		$sourceHandle = $this->getState()->open($this->buildUrl($source), 'r');
-		if (!$sourceHandle) {
-			fclose($targetHandle);
-			throw new InvalidResourceException('Failed opening remote file "' . $source . '" for reading');
 		}
 
 		while ($data = $this->getState()->read($sourceHandle, NativeReadStream::CHUNK_SIZE)) {


### PR DESCRIPTION
I ran into an issue when trying to download a bunch of images from a samba share where I know the images are suffixed with a counter (`image-1.jpg`, `image-2.jpg`...) but not knowing how many images there are. When trying to get `image-3.jpg` for example that doesn't exist, I simply catch the InvalidResourceException and stop looking for pictures. However, that left me with a `image-3.jpg` file target that was 0 bytes.

By swapping the code around, this behaviour is prevented.