### PR TITLE
Optionally skip truncate

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,10 @@ fwrite($fh, 'bar');
 fclose($fh);
 ```
 
-**Note**: write() will truncate your file to 0bytes. You may open a writeable stream with append() which will point
-the cursor to the end of the file or create it if it does not exists yet. (append() is only compatible with libsmbclient-php)
+**Note**: write() will truncate your file to 0bytes and sets the cursor to the beginning. You may set the optional flag `truncate` to `false` to overcome this.
+You may also use append() which will set
+the cursor to the end of the file or create it if it does not exist yet. (append() is only compatible with libsmbclient-php)
+
 ```php
 $fh = $share->append('test.txt');
 fwrite($fh, 'bar');

--- a/src/Native/NativeShare.php
+++ b/src/Native/NativeShare.php
@@ -274,10 +274,10 @@ class NativeShare extends AbstractShare {
 	 * @throws \Icewind\SMB\Exception\NotFoundException
 	 * @throws \Icewind\SMB\Exception\InvalidTypeException
 	 */
-	public function write($source, $truncate=true) {
+	public function write($source, $truncate = true) {
 		$url = $this->buildUrl($source);
 
-		if($truncate === true) {
+		if ($truncate === true) {
 			$handle = $this->getState()->create($url);
 		} else {
 			$handle = $this->getState()->open($url, 'c');

--- a/src/Native/NativeShare.php
+++ b/src/Native/NativeShare.php
@@ -265,17 +265,24 @@ class NativeShare extends AbstractShare {
 
 	/**
 	 * Open a writeable stream to a remote file
-	 * Note: This method will truncate the file to 0bytes first
+	 * Note: The default will truncate the file to 0 bytes.
 	 *
 	 * @param string $source
+	 * @param bool $truncate
 	 * @return resource a writeable stream
 	 *
 	 * @throws \Icewind\SMB\Exception\NotFoundException
 	 * @throws \Icewind\SMB\Exception\InvalidTypeException
 	 */
-	public function write($source) {
+	public function write($source, $truncate=true) {
 		$url = $this->buildUrl($source);
-		$handle = $this->getState()->create($url);
+
+		if($truncate === true) {
+			$handle = $this->getState()->create($url);
+		} else {
+			$handle = $this->getState()->open($url, 'c');
+		}
+
 		return NativeWriteStream::wrap($this->getState(), $handle, 'w', $url);
 	}
 

--- a/src/Wrapped/Share.php
+++ b/src/Wrapped/Share.php
@@ -326,12 +326,18 @@ class Share extends AbstractShare {
 	 * Open a writable stream to a remote file
 	 *
 	 * @param string $target
+	 * @param bool $truncate
 	 * @return resource a write only stream to upload a remote file
 	 *
+	 * @throws \Icewind\SMB\Exception\DependencyException
 	 * @throws \Icewind\SMB\Exception\NotFoundException
 	 * @throws \Icewind\SMB\Exception\InvalidTypeException
 	 */
-	public function write($target) {
+	public function write($target, $truncate=true) {
+		if($truncate === false) {
+			throw new DependencyException('truncate required by smbclient, use php-libsmbclient instead');
+		}
+
 		$target = $this->escapePath($target);
 		// since returned stream is closed by the caller we need to create a new instance
 		// since we can't re-use the same file descriptor over multiple calls

--- a/src/Wrapped/Share.php
+++ b/src/Wrapped/Share.php
@@ -333,8 +333,8 @@ class Share extends AbstractShare {
 	 * @throws \Icewind\SMB\Exception\NotFoundException
 	 * @throws \Icewind\SMB\Exception\InvalidTypeException
 	 */
-	public function write($target, $truncate=true) {
-		if($truncate === false) {
+	public function write($target, $truncate = true) {
+		if ($truncate === false) {
 			throw new DependencyException('truncate required by smbclient, use php-libsmbclient instead');
 		}
 


### PR DESCRIPTION
I need a writable stream with the cursor at the beginning. Neither `write()` nor `append()` does support this. While `write()` sets the cursor to the beginning it also truncates the file completely since https://github.com/eduardok/libsmbclient-php#smbclient_creat gets called.
In my opinion truncating should not be default if write gets called(). One may open a stream but does not write anything and the file gets truncated anyway. This doesn't sound well.
For backwards compatibility I've added a new flag `truncate` which is default `true`. Setting this to `false` will open the file with the mode `c`.

(In a later version it would also be nice to open a file with any mode, provide something like `open(file, mode)`)