### PR TITLE
Fix docblocks in accordance with interface

### DIFF
--- a/src/BasicAuth.php
+++ b/src/BasicAuth.php
@@ -22,19 +22,19 @@
 namespace Icewind\SMB;
 
 class BasicAuth implements IAuth {
-	/** @var string */
+	/** @var string|null */
 	private $username;
-	/** @var string */
+	/** @var string|null */
 	private $workgroup;
-	/** @var string */
+	/** @var string|null */
 	private $password;
 
 	/**
 	 * BasicAuth constructor.
 	 *
-	 * @param string $username
-	 * @param string $workgroup
-	 * @param string $password
+	 * @param string|null $username
+	 * @param string|null $workgroup
+	 * @param string|null $password
 	 */
 	public function __construct($username, $workgroup, $password) {
 		$this->username = $username;


### PR DESCRIPTION
I was running static analysis on my project that uses SMB and noticed it complaining when passing null as value for workgroup. The IAuth interface defines that null is an acceptable value, so I fixed the docblocks in BasicAuth.