### PR TITLE
Add functionality to SMB share

### DIFF
--- a/src/Native/NativeShare.php
+++ b/src/Native/NativeShare.php
@@ -68,7 +68,7 @@ class NativeShare extends AbstractShare {
 
 	private function buildUrl($path) {
 		$this->verifyPath($path);
-		$url = sprintf('smb://%s/%s', $this->server->getHost(), $this->name);
+		$url = str_replace('[USER]', $this->server->getAuth()->getUserName(), sprintf('smb://%s/%s', $this->server->getHost(), $this->name));
 		if ($path) {
 			$path = trim($path, '/');
 			$url .= '/';


### PR DESCRIPTION
With this change it's possible to use the variable "[USER]" when creating an external storage for users. This variable is replaced by the name of the user. In this way, with a single share, we share each one's personal folder only for that user.