### PR TITLE
Get mode from stat first instead of using dos attributes

### DIFF
--- a/src/Native/NativeFileInfo.php
+++ b/src/Native/NativeFileInfo.php
@@ -113,9 +113,14 @@ class NativeFileInfo implements IFileInfo {
 	 */
 	protected function getMode() {
 		if (!$this->modeCache) {
-			$attribute = $this->share->getAttribute($this->path, 'system.dos_attr.mode');
-			// parse hex string
-			$this->modeCache = (int)hexdec(substr($attribute, 2));
+			$stat = $this->stat();
+			if (isset($stat['mode'])) {
+				$this->modeCache = ($stat['mode']);
+			} else {
+				$attribute = $this->share->getAttribute($this->path, 'system.dos_attr.mode');
+				// parse hex string
+				$this->modeCache = (int)hexdec(substr($attribute, 2));
+			}
 		}
 		return $this->modeCache;
 	}

--- a/src/Native/NativeState.php
+++ b/src/Native/NativeState.php
@@ -9,6 +9,7 @@ namespace Icewind\SMB\Native;
 
 use Icewind\SMB\Exception\AlreadyExistsException;
 use Icewind\SMB\Exception\ConnectionRefusedException;
+use Icewind\SMB\Exception\ConnectionResetException;
 use Icewind\SMB\Exception\Exception;
 use Icewind\SMB\Exception\FileInUseException;
 use Icewind\SMB\Exception\ForbiddenException;
@@ -48,6 +49,7 @@ class NativeState {
 		22  => InvalidArgumentException::class,
 		28  => OutOfSpaceException::class,
 		39  => NotEmptyException::class,
+		104 => ConnectionResetException::class,
 		110 => TimedOutException::class,
 		111 => ConnectionRefusedException::class,
 		112 => HostDownException::class,


### PR DESCRIPTION
When connecting to an Isilon based SMB server getMode fails as fetching system.dos_attr.mode causes the server to terminate the connection for some reason. This PR makes sure that a proper exception class is available for the error as well as aligning the mode fetching logic the wrapped getMode implementation where the stat result is used. (https://github.com/icewind1991/SMB/blob/master/src/Wrapped/Share.php#L189)

@icewind1991 Not sure if that might cause issues with other SMB implementations but this fixed the issue that connections work with the wrapper but with libsmbclient-php it was failing with the following trace: 

```
{
  "reqId": "Jcr0V82bneNHDzEpnSyS",
  "level": 3,
  "time": "2019-12-05T15:45:55+00:00",
  "remoteAddr": "141.64.10.50",
  "user": "username",
  "app": "lib",
  "method": "PROPFIND",
  "url": "/remote.php/dav/files/username/",
  "message": {
    "Exception": "Icewind\\SMB\\Exception\\Exception",
    "Message": "Unknown error (104) for /username",
    "Code": 104,
    "Trace": [
      {
        "file": "/var/www/html/apps/files_external/3rdparty/icewind/smb/src/Exception/Exception.php",
        "line": 35,
        "function": "unknown",
        "class": "Icewind\\SMB\\Exception\\Exception",
        "type": "::",
        "args": [
          "/username",
          104
        ]
      },
      {
        "file": "/var/www/html/apps/files_external/3rdparty/icewind/smb/src/Native/NativeState.php",
        "line": 62,
        "function": "fromMap",
        "class": "Icewind\\SMB\\Exception\\Exception",
        "type": "::",
        "args": [
          {
            "1": "Icewind\\SMB\\Exception\\ForbiddenException",
            "2": "Icewind\\SMB\\Exception\\NotFoundException",
            "13": "Icewind\\SMB\\Exception\\ForbiddenException",
            "16": "Icewind\\SMB\\Exception\\FileInUseException",
            "17": "Icewind\\SMB\\Exception\\AlreadyExistsException",
            "20": "Icewind\\SMB\\Exception\\InvalidTypeException",
            "21": "Icewind\\SMB\\Exception\\InvalidTypeException",
            "22": "Icewind\\SMB\\Exception\\InvalidArgumentException",
            "28": "Icewind\\SMB\\Exception\\OutOfSpaceException",
            "39": "Icewind\\SMB\\Exception\\NotEmptyException",
            "110": "Icewind\\SMB\\Exception\\TimedOutException",
            "111": "Icewind\\SMB\\Exception\\ConnectionRefusedException",
            "112": "Icewind\\SMB\\Exception\\HostDownException",
            "113": "Icewind\\SMB\\Exception\\NoRouteToHostException"
          },
          104,
          "/username"
        ]
      },
      {
        "file": "/var/www/html/apps/files_external/3rdparty/icewind/smb/src/Native/NativeState.php",
        "line": 74,
        "function": "handleError",
        "class": "Icewind\\SMB\\Native\\NativeState",
        "type": "->",
        "args": [
          "/username"
        ]
      },
      {
        "file": "/var/www/html/apps/files_external/3rdparty/icewind/smb/src/Native/NativeState.php",
        "line": 289,
        "function": "testResult",
        "class": "Icewind\\SMB\\Native\\NativeState",
        "type": "->",
        "args": [
          false,
          "smb://fileserver.example.de/home/username"
        ]
      },
      {
        "file": "/var/www/html/apps/files_external/3rdparty/icewind/smb/src/Native/NativeShare.php",
        "line": 304,
        "function": "getxattr",
        "class": "Icewind\\SMB\\Native\\NativeState",
        "type": "->",
        "args": [
          "smb://fileserver.example.de/home/username",
          "system.dos_attr.mode"
        ]
      },
      {
        "file": "/var/www/html/apps/files_external/3rdparty/icewind/smb/src/Native/NativeFileInfo.php",
        "line": 116,
        "function": "getAttribute",
        "class": "Icewind\\SMB\\Native\\NativeShare",
        "type": "->",
        "args": [
          "/username",
          "system.dos_attr.mode"
        ]
      },
      {
        "file": "/var/www/html/apps/files_external/3rdparty/icewind/smb/src/Native/NativeFileInfo.php",
        "line": 135,
        "function": "getMode",
        "class": "Icewind\\SMB\\Native\\NativeFileInfo",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/apps/files_external/lib/Lib/Storage/SMB.php",
        "line": 574,
        "function": "isHidden",
        "class": "Icewind\\SMB\\Native\\NativeFileInfo",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/lib/private/Files/Storage/Common.php",
        "line": 146,
        "function": "isUpdatable",
        "class": "OCA\\Files_External\\Lib\\Storage\\SMB",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Storage/Common.php",
        "line": 166,
        "function": "isCreatable",
        "class": "OC\\Files\\Storage\\Common",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Storage/Common.php",
        "line": 696,
        "function": "getPermissions",
        "class": "OC\\Files\\Storage\\Common",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Storage/Wrapper/Wrapper.php",
        "line": 582,
        "function": "getMetaData",
        "class": "OC\\Files\\Storage\\Common",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Storage/Wrapper/PermissionsMask.php",
        "line": 145,
        "function": "getMetaData",
        "class": "OC\\Files\\Storage\\Wrapper\\Wrapper",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Storage/Wrapper/Wrapper.php",
        "line": 582,
        "function": "getMetaData",
        "class": "OC\\Files\\Storage\\Wrapper\\PermissionsMask",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Storage/Wrapper/PermissionsMask.php",
        "line": 145,
        "function": "getMetaData",
        "class": "OC\\Files\\Storage\\Wrapper\\Wrapper",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Storage/Wrapper/Wrapper.php",
        "line": 582,
        "function": "getMetaData",
        "class": "OC\\Files\\Storage\\Wrapper\\PermissionsMask",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Storage/Wrapper/Availability.php",
        "line": 440,
        "function": "getMetaData",
        "class": "OC\\Files\\Storage\\Wrapper\\Wrapper",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Storage/Wrapper/Wrapper.php",
        "line": 582,
        "function": "getMetaData",
        "class": "OC\\Files\\Storage\\Wrapper\\Availability",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Storage/Wrapper/Wrapper.php",
        "line": 582,
        "function": "getMetaData",
        "class": "OC\\Files\\Storage\\Wrapper\\Wrapper",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Cache/Scanner.php",
        "line": 112,
        "function": "getMetaData",
        "class": "OC\\Files\\Storage\\Wrapper\\Wrapper",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Cache/Scanner.php",
        "line": 150,
        "function": "getData",
        "class": "OC\\Files\\Cache\\Scanner",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/View.php",
        "line": 1482,
        "function": "scanFile",
        "class": "OC\\Files\\Cache\\Scanner",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/var/www/html/apps/dav/lib/Connector/Sabre/Directory.php",
        "line": 265,
        "function": "getDirectoryContent",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          "/"
        ]
      },
      {
        "file": "/var/www/html/apps/dav/lib/Connector/Sabre/TagsPlugin.php",
        "line": 224,
        "function": "getChildren",
        "class": "OCA\\DAV\\Connector\\Sabre\\Directory",
        "type": "->",
        "args": []
      },
      {
        "function": "handleGetProperties",
        "class": "OCA\\DAV\\Connector\\Sabre\\TagsPlugin",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\DAV\\PropFind"
          },
          {
            "__class__": "OCA\\DAV\\Files\\FilesHome"
          }
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/event/lib/EventEmitterTrait.php",
        "line": 105,
        "function": "call_user_func_array",
        "args": [
          [
            {
              "__class__": "OCA\\DAV\\Connector\\Sabre\\TagsPlugin"
            },
            "handleGetProperties"
          ],
          [
            {
              "__class__": "Sabre\\DAV\\PropFind"
            },
            {
              "__class__": "OCA\\DAV\\Files\\FilesHome"
            }
          ]
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 1059,
        "function": "emit",
        "class": "Sabre\\Event\\EventEmitter",
        "type": "->",
        "args": [
          "propFind",
          [
            {
              "__class__": "Sabre\\DAV\\PropFind"
            },
            {
              "__class__": "OCA\\DAV\\Files\\FilesHome"
            }
          ]
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 981,
        "function": "getPropertiesByNode",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\DAV\\PropFind"
          },
          {
            "__class__": "OCA\\DAV\\Files\\FilesHome"
          }
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 1666,
        "function": "getPropertiesIteratorForPath",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "files/username",
          [
            "{DAV:}getlastmodified",
            "{DAV:}getetag",
            "{DAV:}getcontenttype",
            "{DAV:}resourcetype",
            "{http://owncloud.org/ns}fileid",
            "{http://owncloud.org/ns}permissions",
            "{http://owncloud.org/ns}size",
            "{DAV:}getcontentlength",
            "{http://nextcloud.org/ns}has-preview",
            "{http://nextcloud.org/ns}mount-type",
            "{http://nextcloud.org/ns}is-encrypted",
            "{http://open-collaboration-services.org/ns}share-permissions",
            "{http://owncloud.org/ns}tags",
            "{http://owncloud.org/ns}favorite",
            "{http://owncloud.org/ns}comments-unread",
            "{http://owncloud.org/ns}owner-id",
            "{http://owncloud.org/ns}owner-display-name",
            "{http://owncloud.org/ns}share-types"
          ],
          1
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
        "line": 355,
        "function": "generateMultiStatus",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          {
            "__class__": "Generator"
          },
          false
        ]
      },
      {
        "function": "httpPropFind",
        "class": "Sabre\\DAV\\CorePlugin",
        "type": "->",
        "args": [
          {
            "absoluteUrl": "https://cloud.example.de/remote.php/dav/files/username/",
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/event/lib/EventEmitterTrait.php",
        "line": 105,
        "function": "call_user_func_array",
        "args": [
          [
            {
              "__class__": "Sabre\\DAV\\CorePlugin"
            },
            "httpPropFind"
          ],
          [
            {
              "absoluteUrl": "https://cloud.example.de/remote.php/dav/files/username/",
              "__class__": "Sabre\\HTTP\\Request"
            },
            {
              "__class__": "Sabre\\HTTP\\Response"
            }
          ]
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 479,
        "function": "emit",
        "class": "Sabre\\Event\\EventEmitter",
        "type": "->",
        "args": [
          "method:PROPFIND",
          [
            {
              "absoluteUrl": "https://cloud.example.de/remote.php/dav/files/username/",
              "__class__": "Sabre\\HTTP\\Request"
            },
            {
              "__class__": "Sabre\\HTTP\\Response"
            }
          ]
        ]
      },
      {
        "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 254,
        "function": "invokeMethod",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          {
            "absoluteUrl": "https://cloud.example.de/remote.php/dav/files/username/",
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/var/www/html/apps/dav/lib/Server.php",
        "line": 316,
        "function": "exec",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/apps/dav/appinfo/v2/remote.php",
        "line": 35,
        "function": "exec",
        "class": "OCA\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/remote.php",
        "line": 163,
        "args": [
          "/var/www/html/apps/dav/appinfo/v2/remote.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/var/www/html/apps/files_external/3rdparty/icewind/smb/src/Exception/Exception.php",
    "Line": 17,
    "CustomMessage": "Exception while scanning storage \"smb::username@fileserver.example.de//home//username/\""
  },
  "userAgent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:70.0) Gecko/20100101 Firefox/70.0",
  "version": "16.0.6.1"
}
```