### PR TITLE
Ignore ATTR_NOT_CONTENT_INDEXED

### DIFF
--- a/src/Native/NativeFileInfo.php
+++ b/src/Native/NativeFileInfo.php
@@ -108,6 +108,11 @@ class NativeFileInfo implements IFileInfo {
 	 * @return int
 	 */
 	protected function getMode() {
+		$mode = $this->stat()['mode'];
+
+		// Let us ignore the ATTR_NOT_CONTENT_INDEXED for now
+		$mode &= ~0x00002000;
+		
 		return $this->stat()['mode'];
 	}
 


### PR DESCRIPTION
See: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/65e0c225-5925-44b0-8104-6b91339c709f

I'm not sure if this runs into other issues. But I ran into several servers that have 0x2000 set. (so don't index) but still just use the normal directory modes etc (0x10) instead of (0x4000)