### PR TITLE
Support PHP 7.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
           - smbclient
           - libsmbclient
         php-version:
+          - "7.2"
           - "7.3"
           - "7.4"
           - "8.0"

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
 		}
 	],
 	"require"          : {
-		"php": ">=7.3",
+		"php": ">=7.2",
 		"icewind/streams": ">=0.7.3"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^9.3.8",
+		"phpunit/phpunit": "^8.5|^9.3.8",
 		"friendsofphp/php-cs-fixer": "^2.16",
     "phpstan/phpstan": "^0.12.57"
 	},


### PR DESCRIPTION
Fixes #100 

The existing code and unit tests pass with PHP 7.2 and phpunit 8. So, IMO, might as well support it for now.