### PR TITLE
Fix incorrect read from StringBuffer with starting offset > 0

### DIFF
--- a/src/StringBuffer.php
+++ b/src/StringBuffer.php
@@ -44,7 +44,7 @@ class StringBuffer {
 	}
 
 	public function read(int $count): string {
-		$chunk = substr($this->buffer, $this->pos, $this->pos + $count);
+		$chunk = substr($this->buffer, $this->pos, $count);
 		$this->pos += strlen($chunk);
 		return $chunk;
 	}


### PR DESCRIPTION
Repeating reads from the StringBuffer advance the read position. The read incorrectly adds position & count which results in unexpected behavior of increasing return values.