### PR TITLE
fix check with krb constrained delegation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,6 +208,7 @@ jobs:
     name: Psalm static analysis
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "7.2"

--- a/src/KerberosApacheAuth.php
+++ b/src/KerberosApacheAuth.php
@@ -78,6 +78,7 @@ class KerberosApacheAuth extends KerberosAuth implements IAuth {
 	 * Check if a valid kerberos ticket is present
 	 *
 	 * @return bool
+	 * @psalm-assert-if-true string $this->ticketName
 	 */
 	public function checkTicket(): bool {
 		//read apache kerberos ticket cache
@@ -87,6 +88,7 @@ class KerberosApacheAuth extends KerberosAuth implements IAuth {
 
 		$krb5 = new \KRB5CCache();
 		$krb5->open($this->ticketName);
+		/** @psalm-suppress MixedArgument */
 		return count($krb5->getEntries()) > 0;
 	}
 

--- a/src/KerberosApacheAuth.php
+++ b/src/KerberosApacheAuth.php
@@ -31,19 +31,8 @@ class KerberosApacheAuth extends KerberosAuth implements IAuth {
 	/** @var string */
 	private $ticketPath = "";
 
-	// only working with specific library (mod_auth_kerb, krb5, smbclient) versions
-	/** @var bool */
-	private $saveTicketInMemory = false;
-
 	/** @var bool */
 	private $init = false;
-
-	/**
-	 * @param bool $saveTicketInMemory
-	 */
-	public function __construct(bool $saveTicketInMemory = false) {
-		$this->saveTicketInMemory = $saveTicketInMemory;
-	}
 
 	/**
 	 * Check if a valid kerberos ticket is present

--- a/src/KerberosApacheAuth.php
+++ b/src/KerberosApacheAuth.php
@@ -106,7 +106,11 @@ class KerberosApacheAuth extends KerberosAuth implements IAuth {
 
 	public function setExtraSmbClientOptions($smbClientState): void {
 		$this->init();
-		parent::setExtraSmbClientOptions($smbClientState);
+		try {
+			parent::setExtraSmbClientOptions($smbClientState);
+		} catch (Exception $e) {
+			// suppress
+		}
 	}
 
 	public function __destruct() {

--- a/src/KerberosApacheAuth.php
+++ b/src/KerberosApacheAuth.php
@@ -59,7 +59,7 @@ class KerberosApacheAuth extends KerberosAuth implements IAuth {
 
 		$krb5 = new \KRB5CCache();
 		$krb5->open($cacheFile);
-		return (bool)$krb5->isValid();
+		return count($krb5->getEntries()) > 0;
 	}
 
 	private function init(): void {

--- a/src/KerberosApacheAuth.php
+++ b/src/KerberosApacheAuth.php
@@ -76,27 +76,10 @@ class KerberosApacheAuth extends KerberosAuth implements IAuth {
 
 		//read apache kerberos ticket cache
 		$cacheFile = getenv("KRB5CCNAME");
-		if (!$cacheFile) {
+		if (!$this->checkTicket()) {
 			throw new Exception('No kerberos ticket cache environment variable (KRB5CCNAME) found.');
 		}
-
-		$krb5 = new \KRB5CCache();
-		$krb5->open($cacheFile);
-		if (!$krb5->isValid()) {
-			throw new Exception('Kerberos ticket cache is not valid.');
-		}
-
-
-		if ($this->saveTicketInMemory) {
-			putenv("KRB5CCNAME=" . (string)$krb5->getName());
-		} else {
-			//workaround: smbclient is not working with the original apache ticket cache.
-			$tmpFilename = tempnam("/tmp", "krb5cc_php_");
-			$tmpCacheFile = "FILE:" . $tmpFilename;
-			$krb5->save($tmpCacheFile);
-			$this->ticketPath = $tmpFilename;
-			putenv("KRB5CCNAME=" . $tmpCacheFile);
-		}
+		putenv("KRB5CCNAME=" . $cacheFile);
 	}
 
 	public function getExtraCommandLineArguments(): string {


### PR DESCRIPTION
With Constrained Delegation the ticket has a different format so that `isValid()` does not report the correct state.