### PR TITLE
When access is denied to a sub-folder an empty list of files is returned instead of an error.

### DIFF
--- a/src/Wrapped/Share.php
+++ b/src/Wrapped/Share.php
@@ -179,6 +179,8 @@ class Share extends AbstractShare {
 		$output = $this->execute('dir');
 
 		$this->execute('cd /');
+		//check output for errors
+		$this->parseOutput($output, $path);
 
 		return $this->parser->parseDir($output, $path, function (string $path) {
 			return $this->getAcls($path);


### PR DESCRIPTION
When access is denied to a subfolder, dir() will successfully execute 'cd', but 'dir' will fail. In this case, an empty list of files is returned instead of an error. Added parseOutput() after execute() to check for errors.