### PR TITLE
IShare.php - Typo in PHPDoc for get / put: remove file -> remote file

### DIFF
--- a/src/IShare.php
+++ b/src/IShare.php
@@ -23,7 +23,7 @@ interface IShare {
 	/**
 	 * Download a remote file
 	 *
-	 * @param string $source remove file
+	 * @param string $source remote file
 	 * @param string $target local file
 	 * @return bool
 	 *
@@ -36,7 +36,7 @@ interface IShare {
 	 * Upload a local file
 	 *
 	 * @param string $source local file
-	 * @param string $target remove file
+	 * @param string $target remote file
 	 * @return bool
 	 *
 	 * @throws NotFoundException


### PR DESCRIPTION
Fixed typo in PHPDoc block ISahre.php get() and put(). Changed 'remove' file to 'remote' file.