### PR TITLE
Reset pointer to the beginning of authentication file

### DIFF
--- a/src/Wrapped/RawConnection.php
+++ b/src/Wrapped/RawConnection.php
@@ -213,6 +213,7 @@ class RawConnection {
 
 		$this->authStream = fopen('php://temp', 'w+');
 		fwrite($this->authStream, $auth);
+		rewind($this->authStream);
 	}
 
 	/**


### PR DESCRIPTION
If the authentication file stream isn't rewinded to the beggining the authentication fails on macOS using latest available smbclient from Homebrew (v 4.21.0)